### PR TITLE
Initialize Discord Battlemap Bot scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Discord Battlemap Bot
+
+This is a full-stack Node.js application that simulates a Discord bot for managing tabletop battle maps. The project is split into a backend API built with Express and MongoDB and a frontend built with React and TailwindCSS.
+
+## Project Structure
+
+- `backend` – Express server, MongoDB models, and RESTful routes
+- `frontend` – React single-page application using Vite
+- `shared` – Shared logic and schemas
+
+## Setup
+
+1. Install all dependencies:
+
+```bash
+npm run install-all
+```
+
+2. Create a `.env` file in `backend` with the following variables:
+
+```
+MONGO_URI=<your mongodb uri>
+PORT=5000
+```
+
+3. Start the development servers:
+
+```bash
+npm run dev
+```
+
+The frontend will be available at `http://localhost:3000` and proxy API calls to the backend running on port `5000`.
+
+## Commands
+
+- `POST /api/maps/create` – create a new map
+- `POST /api/maps/:mapId/token` – add a token
+- `POST /api/maps/token/:tokenId/move` – move a token
+- `GET /api/maps/:mapId/save` – save a map
+- `GET /api/maps/:mapId/load` – load a map
+
+## Contributing
+
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+## License
+
+MIT

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+MONGO_URI=mongodb://localhost:27017/battlemap
+PORT=5000

--- a/backend/controllers/mapsController.js
+++ b/backend/controllers/mapsController.js
@@ -1,0 +1,55 @@
+import Map from '../models/Map.js';
+import Token from '../models/Token.js';
+
+export const createMap = async (req, res) => {
+  try {
+    const { name, width, height } = req.body;
+    const map = await Map.create({ name, width, height, tokens: [] });
+    res.json({ message: `Map '${map.name}' created.` });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+export const addToken = async (req, res) => {
+  try {
+    const { mapId } = req.params;
+    const { name, x, y, image, meta } = req.body;
+    const token = await Token.create({ name, x, y, image, meta });
+    const map = await Map.findByIdAndUpdate(mapId, { $push: { tokens: token._id } }, { new: true });
+    res.json({ message: `Token '${token.name}' added to map '${map.name}'.`, token });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+export const moveToken = async (req, res) => {
+  try {
+    const { tokenId } = req.params;
+    const { x, y } = req.body;
+    const token = await Token.findByIdAndUpdate(tokenId, { x, y }, { new: true });
+    res.json({ message: `Token '${token.name}' moved to (${x}, ${y}).`, token });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+export const saveMap = async (req, res) => {
+  try {
+    const { mapId } = req.params;
+    const map = await Map.findById(mapId).populate('tokens');
+    res.json({ message: `Map '${map.name}' saved.`, map });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};
+
+export const loadMap = async (req, res) => {
+  try {
+    const { mapId } = req.params;
+    const map = await Map.findById(mapId).populate('tokens');
+    res.json({ message: `Map '${map.name}' loaded.`, map });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,24 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import cors from 'cors';
+import dotenv from 'dotenv';
+import mapRoutes from './routes/maps.js';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/maps', mapRoutes);
+
+const PORT = process.env.PORT || 5000;
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/battlemap';
+
+mongoose.connect(MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true })
+  .then(() => {
+    app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+  })
+  .catch((err) => {
+    console.error('MongoDB connection error:', err);
+  });

--- a/backend/models/Map.js
+++ b/backend/models/Map.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+
+const Schema = mongoose.Schema;
+
+const mapSchema = new Schema({
+  name: { type: String, required: true },
+  width: { type: Number, required: true },
+  height: { type: Number, required: true },
+  tokens: [{ type: Schema.Types.ObjectId, ref: 'Token' }]
+});
+
+export default mongoose.model('Map', mapSchema);

--- a/backend/models/Token.js
+++ b/backend/models/Token.js
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+
+const Schema = mongoose.Schema;
+
+const tokenSchema = new Schema({
+  name: { type: String, required: true },
+  x: { type: Number, required: true },
+  y: { type: Number, required: true },
+  image: { type: String },
+  meta: { type: Object }
+});
+
+export default mongoose.model('Token', tokenSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "discord-battlemap-bot-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "nodemon index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "mongoose": "^7.0.3"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}

--- a/backend/routes/maps.js
+++ b/backend/routes/maps.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import { createMap, addToken, moveToken, saveMap, loadMap } from '../controllers/mapsController.js';
+
+const router = express.Router();
+
+router.post('/create', createMap);          // /api/maps/create
+router.post('/:mapId/token', addToken);     // /api/maps/:mapId/token
+router.post('/token/:tokenId/move', moveToken); // /api/maps/token/:tokenId/move
+router.get('/:mapId/save', saveMap);        // /api/maps/:mapId/save
+router.get('/:mapId/load', loadMap);        // /api/maps/:mapId/load
+
+export default router;

--- a/backend/utils/validatePosition.js
+++ b/backend/utils/validatePosition.js
@@ -1,0 +1,3 @@
+export function isValidPosition(x, y, width, height) {
+  return x >= 0 && y >= 0 && x < width && y < height;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Discord Battlemap Bot</title>
+  </head>
+  <body class="bg-gray-800 text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "discord-battlemap-bot-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.13",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.2",
+    "vite": "^4.3.9",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/postcss.config.cjs
+++ b/frontend/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ChatFeed from './components/ChatFeed.jsx';
+import CommandInput from './components/CommandInput.jsx';
+import MapGrid from './components/MapGrid.jsx';
+
+function App() {
+  return (
+    <div className="flex h-screen">
+      <div className="flex flex-col flex-1">
+        <ChatFeed />
+        <CommandInput />
+      </div>
+      <div className="w-1/2 bg-gray-700">
+        <MapGrid />
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/ChatFeed.jsx
+++ b/frontend/src/components/ChatFeed.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function ChatFeed() {
+  return (
+    <div className="flex-1 overflow-y-auto p-4 bg-gray-900">
+      {/* Chat messages will appear here */}
+    </div>
+  );
+}
+
+export default ChatFeed;

--- a/frontend/src/components/CommandInput.jsx
+++ b/frontend/src/components/CommandInput.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+function CommandInput() {
+  const [command, setCommand] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // handle command submission
+    setCommand('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-2 bg-gray-800">
+      <input
+        className="w-full p-2 rounded bg-gray-700 text-white"
+        placeholder="Enter command..."
+        value={command}
+        onChange={(e) => setCommand(e.target.value)}
+      />
+    </form>
+  );
+}
+
+export default CommandInput;

--- a/frontend/src/components/MapGrid.jsx
+++ b/frontend/src/components/MapGrid.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+function MapGrid() {
+  // Basic placeholder grid
+  const size = 10;
+  const tiles = [];
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      tiles.push(
+        <div key={`${x}-${y}`} className="w-8 h-8 border border-gray-600"></div>
+      );
+    }
+  }
+
+  return <div className="grid grid-cols-10">{tiles}</div>;
+}
+
+export default MapGrid;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "battlemap-bot",
+  "name": "discord-battlemap-bot",
   "version": "1.0.0",
-  "main": "index.js",
+  "private": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "concurrently \"npm run dev --prefix backend\" \"npm run dev --prefix frontend\"",
+    "install-all": "npm install --prefix backend && npm install --prefix frontend"
   },
-  "author": "",
-  "license": "ISC",
-  "description": ""
+  "devDependencies": {
+    "concurrently": "^7.6.0"
+  }
 }

--- a/shared/commands.js
+++ b/shared/commands.js
@@ -1,0 +1,8 @@
+// Shared command schema placeholders
+export const COMMANDS = {
+  CREATE_MAP: '/create-map',
+  ADD_TOKEN: '/add-token',
+  MOVE_TOKEN: '/move-token',
+  SAVE_MAP: '/save-map',
+  LOAD_MAP: '/load-map'
+};


### PR DESCRIPTION
## Summary
- set up backend with Express, Mongoose, and API routes
- scaffold frontend using Vite/React with TailwindCSS
- add shared command definitions
- provide root scripts to run both servers concurrently
- document setup and API in README

## Testing
- `npm run install-all` *(fails: 403 Forbidden while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68574f6b23108325b859e9944130b520